### PR TITLE
Fix Tailwind PostCSS plugin

### DIFF
--- a/frontend/postcss.config.mjs
+++ b/frontend/postcss.config.mjs
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
## Summary
- adjust PostCSS configuration to use `@tailwindcss/postcss`

## Testing
- `npm run --silent --prefix frontend lint` *(fails: package not found)*


------
https://chatgpt.com/codex/tasks/task_e_6845cc9cf3a88325822ed015f14d0fa4